### PR TITLE
fix: wrong url of css and scripts when opening portal in issue #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ yarn-error.log*
 /node
 /target
 /keycloak.v2
+
+/.idea
+/phasetwo-admin-portal.iml
+/package-lock.json

--- a/ext/main/java/io/phasetwo/portal/PortalResourceProvider.java
+++ b/ext/main/java/io/phasetwo/portal/PortalResourceProvider.java
@@ -168,6 +168,10 @@ public class PortalResourceProvider implements RealmResourceProvider {
           session
               .getProvider(LoginFormsProvider.class)
               .setAttribute("environment", envStr)
+              .setAttribute("authUrl", authUrl.getPath().endsWith("/") ? authUrl.toString().substring(0, authUrl.toString().length() - 1) : authUrl.toString())
+              .setAttribute("faviconUrl", Optional.ofNullable(realm.getAttribute(String.format("_providerConfig.assets.favicon.url"))).orElse("${authUrl}/realms/${realmName}/portal/favicon.ico"))
+              .setAttribute("appiconUrl", Optional.ofNullable(realm.getAttribute(String.format("_providerConfig.assets.appicon.url"))).orElse("${authUrl}/realms/${realmName}/portal/logo192.png"))
+              .setAttribute("displayName", Optional.ofNullable(realm.getDisplayName()).orElse(realm.getName()))
               .setAttribute("realmName", realm.getName());
       FreeMarkerLoginFormsProvider fm = (FreeMarkerLoginFormsProvider) form;
       Method processTemplateMethod =

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "build-mvn": "PUBLIC_URL='/auth/realms/${realmName}/portal' react-scripts build",
+    "build-mvn": "PUBLIC_URL='${authUrl}/realms/${realmName}/portal' react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "orgs-api": "npx @rtk-query/codegen-openapi orgs-openapi-config.ts",

--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,14 @@
     <meta
       id="appName"
       name="application-name"
-      content="${realmName} Admin Portal"
+      content="${displayName} Admin Portal"
     />
-    <meta name="description" content="${realmName} Admin Portal" />
+    <meta name="description" content="${displayName} Admin Portal" />
     <base href="%PUBLIC_URL%/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="icon" href="${faviconUrl}" />
+    <link rel="apple-touch-icon" href="${appiconUrl}" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -27,7 +27,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>${realmName} Admin Portal</title>
+    <title>${displayName} Admin Portal</title>
     <script>
       var environment = {};
       try {


### PR DESCRIPTION
In issue #87, modifying the config.ts file was not sufficient, and the problem was not solved, because of page generation through the template engine.
So for issue #89, I had to change: 

- the template index.html
- the io.phasetwo.portal.PortalResourceProvider.java class
- the build-mvn script in the package.json

Then the base url is constructed at runtime by the PortalResourceProvider and injected in template.