### PR TITLE
Adds user disabled indicator to members list

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -45,6 +45,7 @@
   "device-activity": "Device activity",
   "deviceActivity": "Device activity",
   "directMembership": "Direct membership",
+  "disabled": "Disabled",
   "displayName": "Display name",
   "doCancel": "Cancel",
   "doDeny": "Deny",

--- a/src/components/elements/table/members-table.tsx
+++ b/src/components/elements/table/members-table.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { TableRows } from "./table";
+import { Lock } from "lucide-react";
 
 type Props = {
   rows: TableRows;
@@ -15,6 +16,13 @@ const loading = (
 
 const MembersTable: React.FC<Props> = ({ rows, isLoading }) => {
   const { t } = useTranslation();
+
+  const disabledInfo = (
+    <span className="mt-1 inline-flex text-sm text-orange-600 md:mt-0">
+      {t("disabled")} <Lock className="ml-2 h-5 w-5" />
+    </span>
+  );
+
   return (
     <div className="rounded border border-gray-200 dark:border-zinc-600">
       {isLoading && loading}
@@ -29,6 +37,7 @@ const MembersTable: React.FC<Props> = ({ rows, isLoading }) => {
                 <div className="text-sm text-gray-500 dark:text-zinc-500">
                   {item["email"]}
                 </div>
+                {item["enabled"] === false && disabledInfo}
                 <div className="space-y-1 py-2">{item["roles"]}</div>
                 <div>{item["action"]}</div>
               </div>
@@ -46,8 +55,10 @@ const MembersTable: React.FC<Props> = ({ rows, isLoading }) => {
                           {t("admin")}
                         </div>
                       </td>
-                      <td className="space-x-2 px-5 py-4 text-right align-middle"></td>
-                      <td className="px-1 py-4 text-right align-middle"></td>
+                      <td
+                        colSpan={2}
+                        className="space-x-2 px-5 py-4 text-right align-middle"
+                      ></td>
                       <td className="px-1 py-4 text-right align-middle">
                         <div className="h-[40px]"></div>
                       </td>
@@ -65,10 +76,13 @@ const MembersTable: React.FC<Props> = ({ rows, isLoading }) => {
                         {item["email"]}
                       </div>
                     </td>
+                    <td className="w-1/4 space-x-2 px-5 py-4 text-right align-middle">
+                      {item["enabled"] === false && disabledInfo}
+                    </td>
                     <td className="space-x-2 px-5 py-4 text-right align-middle">
                       {item["roles"]}
                     </td>
-                    <td className="px-1 py-4 text-right align-middle">
+                    <td className="px-1 py-4 pr-4 text-right align-middle">
                       {item["action"]}
                     </td>
                   </tr>

--- a/src/pages/organizations/detail.tsx
+++ b/src/pages/organizations/detail.tsx
@@ -96,6 +96,7 @@ export default function OrganizationDetail() {
   const rows: TableRows = members.map((member) => ({
     email: member.email,
     name: `${member.firstName || ""} ${member.lastName || ""}`.trim(),
+    enabled: member.enabled,
     roles: <MemberRoles member={member} orgId={orgId!} realm={realm} />,
     action: <MembersActionMenu member={member} orgId={orgId!} realm={realm} />,
   }));


### PR DESCRIPTION
Partly resolves #97 

Adds user disabled indicator to members list if the user account is disabled. There is no special indicator for enabled users, as that will be the most common case.

On smaller screens:
![Screenshot_DisabledSmallScreen](https://github.com/p2-inc/phasetwo-admin-portal/assets/25788444/97c597dc-e320-4b88-895a-c3771c53594f)

On wider screens:
![Screenshot_DisabledWide](https://github.com/p2-inc/phasetwo-admin-portal/assets/25788444/c4d6ed6d-1d5f-472b-ab9f-287089550232)
