### PR TITLE
adjust the grid layout of items to avoid overflow and wrapping issues

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -132,7 +132,7 @@
   "notInUse": "Not in use",
   "notSetUp": "{{0}} is not set up.",
   "offlineAccess": "Offline access",
-  "openOptions": "Open options",
+  "options": "Options",
   "organization": "Organization",
   "organizations": "Organizations",
   "otp-display-name": "Authenticator application",

--- a/src/components/elements/organizations/action-card.tsx
+++ b/src/components/elements/organizations/action-card.tsx
@@ -6,15 +6,17 @@ type Props = {
 };
 
 export const OACTopRow: FC<Props> = ({ children }) => (
-  <div className="space-y-3 md:flex md:space-y-0 md:space-x-10">{children}</div>
+  <div className="flex-wrap justify-between space-y-3 md:flex md:space-y-1 md:space-x-1">
+    {children}
+  </div>
 );
 
 const OrganizationActionCard: FC<Props> = ({ children }) => {
   return (
-    <div className={cs("block")}>
-      <div className="relative">
-        <div className="relative z-20">
-          <div className="col-span-1 flex flex-col justify-between space-y-6 rounded-md border border-gray-200 p-4 dark:border-zinc-600 md:py-9 md:px-10">
+    <div className="block">
+      <div className="relative h-full">
+        <div className="relative z-20 h-full overflow-hidden">
+          <div className="col-span-1 flex h-full flex-col justify-between space-y-6 rounded-md border border-gray-200 p-4 dark:border-zinc-600 md:py-9 md:px-10">
             {children}
           </div>
         </div>

--- a/src/pages/organizations/components/member-action-menu.tsx
+++ b/src/pages/organizations/components/member-action-menu.tsx
@@ -77,10 +77,10 @@ export default function MembersActionMenu({ member, orgId, realm }: Props) {
           <Menu.Button className="w-full">
             <div className="flex w-full items-center justify-center space-x-2 rounded border border-gray-200 py-1 px-4 text-sm transition hover:border-gray-800 md:border-transparent md:px-1 dark:md:border-zinc-800 dark:md:hover:border-zinc-600">
               <EllipsisVerticalIcon
-                className="h-5 w-5 dark:fill-zinc-200"
+                className="h-5 w-5 dark:fill-zinc-200 max-md:hidden"
                 aria-hidden="true"
               />
-              <span className="md:hidden">{t("openOptions")}</span>
+              <span className="md:hidden">{t("options")}</span>
             </div>
           </Menu.Button>
         </div>


### PR DESCRIPTION
<img width="955" alt="image" src="https://github.com/p2-inc/phasetwo-admin-portal/assets/93841792/ba8da162-5bf3-43d4-9b8b-74dcf64a597b">

Fix #99 