### PR TITLE
:bug: wrong condition for username same as email

### DIFF
--- a/src/pages/profile/components/profile.tsx
+++ b/src/pages/profile/components/profile.tsx
@@ -80,7 +80,7 @@ const ProfileData = () => {
       </div>
       <form className="max-w-xl space-y-4" onSubmit={handleSubmit(onSubmit)}>
         <>
-          {!featureFlags.registrationEmailAsUsername ? (
+          {featureFlags.registrationEmailAsUsername ? (
             // Username is email, can edit username but must be a valid email
             <RHFFormTextInputWithLabel
               slug="username"


### PR DESCRIPTION
Hi,

During some testing, I have noticed that when I set
`registrationEmailAsUsername: true`

I was getting this behaviour:
![image](https://github.com/p2-inc/phasetwo-admin-portal/assets/16251642/8cffa78f-ccc5-4eb9-b69e-c03e8196542c)

And when I set 
`registrationEmailAsUsername: false`

I was getting this behaviour:
![image](https://github.com/p2-inc/phasetwo-admin-portal/assets/16251642/11db5600-af74-433d-9766-5ad899ae6c69)

I was able to reproduce it with a container by playing with the `Realm Settings -> Email as username` toggle.

---

Now with this fix, when I set 
`registrationEmailAsUsername: false`

I get the expected behaviour:
![image](https://github.com/p2-inc/phasetwo-admin-portal/assets/16251642/16cdcf5a-1cff-43e2-819a-79ccc45f7bc1)
